### PR TITLE
Correct the installation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fast, git-aware, space-conscious, [Powerline](https://github.com/powerline/fonts
 With [Fisher](https://github.com/jorgebucaran/fisher)
 
 ```fish
-fisher add fishpkg/fish-prompt-metro
+fisher add lowne/fish-prompt-metro
 ```
 
 ## Configuration


### PR DESCRIPTION
[fishpkg/fish-prompt-metro](https://github.com/fishpkg/fish-prompt-metro) redirects to another repo which is not related to this theme (anymore?)